### PR TITLE
All REST methods provided within swagger config are now collected int…

### DIFF
--- a/get.yaml
+++ b/get.yaml
@@ -34,7 +34,36 @@ paths:
             $ref: '#/definitions/shop'
         default:
           $ref: '#/responses/errorResponse'
-
+  /shops/{sss}:
+    parameters:
+      - $ref: '#/parameters/name'
+    get:
+      tags:
+        - shops
+      operationId: getShop
+      description: get Shop details by its name
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/shop'
+        default:
+          $ref: '#/responses/errorResponse'
+  /shops/{aaa}:
+    parameters:
+      - $ref: '#/parameters/name'
+    post:
+      tags:
+        - shops
+      operationId: getShop
+      description: get Shop details by its name
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/shop'
+        default:
+          $ref: '#/responses/errorResponse'
 parameters:
   name:
     description: models name getter

--- a/warp.go
+++ b/warp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/misnaged/annales/logger"
 	"warp_swagger/yaml_parser"
 )
@@ -11,5 +12,12 @@ func main() {
 	if err != nil {
 		logger.Log().Errorf("%v", err)
 	}
-	p.CollectRESTmethods()
+
+	m, err := p.CollectRESTmethods()
+	if err != nil {
+		logger.Log().Errorf("%v", err)
+	}
+	for i := range m {
+		fmt.Println(m[i])
+	}
 }

--- a/yaml_parser/parser.go
+++ b/yaml_parser/parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"gopkg.in/yaml.v3"
 	"warp_swagger/config_swagger"
+	"warp_swagger/utils"
 )
 
 type Parser struct {
@@ -24,27 +25,56 @@ func NewParser(path string) (*Parser, error) {
 
 var ErrNilMap = errors.New("path map is nil")
 
-func (p *Parser) CollectRESTmethods() error {
+// countRESTmethods needed to sum all REST methods
+// being provided within swagger config and return the sum number
+// Basically, needed only for CollectRESTmethods
+// where we need to set the length of []map[string]any
+func (p *Parser) countRESTmethods() (int, error) {
+	var count int
 	m := p.SwaggerCfg.SwagBP.PathsMap
-	//pm := m[title].([]*yaml.Node)
-	//if pm == nil {
-	//	return ErrNilMap
-	//}
 	for title := range m {
 		pm := m[title].([]*yaml.Node)
 		if pm == nil {
-			return ErrNilMap
+			return 0, ErrNilMap
 		}
 		for i := range pm {
 			switch pm[i].Value {
 			case "post":
-				fmt.Println("post detected")
+				count += 1
 			case "get":
-				fmt.Println("get detected")
+				count += 1
+			}
+		}
+	}
+	return count, nil
+}
 
+// CollectRESTmethods searching any (post and get, at this time) kind of REST methods
+// in the 'paths' section of config (where they normally should be defined)
+func (p *Parser) CollectRESTmethods() ([]map[string]any, error) {
+	m := p.SwaggerCfg.SwagBP.PathsMap
+	count, err := p.countRESTmethods()
+	if err != nil {
+		return nil, fmt.Errorf("error while counting rest methods: %w", err)
+	}
+	restMap := make([]map[string]any, count)
+
+	restMap = append(restMap[count:]) // cut empty maps
+
+	for title := range m {
+		pm := m[title].([]*yaml.Node)
+		if pm == nil {
+			return nil, ErrNilMap
+		}
+		for i := range pm {
+			switch pm[i].Value {
+			case "post":
+				restMap = append(restMap, utils.Unwrap(pm))
+			case "get":
+				restMap = append(restMap, utils.Unwrap(pm))
 			}
 		}
 
 	}
-	return nil
+	return restMap, nil
 }


### PR DESCRIPTION
…o `[]map[string]any`...